### PR TITLE
Include counter prop for accordion card

### DIFF
--- a/src/components/accordion-card/accordion-card-styles.scss
+++ b/src/components/accordion-card/accordion-card-styles.scss
@@ -40,6 +40,18 @@
   justify-content: space-between;
 }
 
+.groupCounter {
+  width: 30px;
+  height: 30px;
+  margin-right: 15px;
+  border-radius: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $white;
+  background-color: $primary-color;
+}
+
 .icon {
   transform: rotate(90deg);
   fill: $turquoise;

--- a/src/components/accordion-card/accordion-card.js
+++ b/src/components/accordion-card/accordion-card.js
@@ -18,7 +18,7 @@ class AccordionCard extends Component {
   };
 
   render() {
-    const { icon, title, children, theme } = this.props;
+    const { icon, title, children, counter, theme } = this.props;
     const { isOpen } = this.state;
     return (
       <div className={cx(styles.cardWrapper, theme.cardWrapper)}>
@@ -31,22 +31,34 @@ class AccordionCard extends Component {
             <h2 className={cx(styles.groupTitle, theme.groupTitle)}>
               {title}
             </h2>
-            <Button
-              onClick={this.toggleCard}
-              theme={{ button: styles.toggleButton }}
-            >
+            <div className={styles.headerContainer}>
               {
-                icon &&
+                counter &&
                   (
-                    <Icon
-                      icon={icon}
-                      theme={{
-                        icon: isOpen ? styles.icon : styles.iconCollapse
-                      }}
-                    />
+                    <span
+                      className={cx(styles.groupCounter, theme.groupCounter)}
+                    >
+                      {counter}
+                    </span>
                   )
               }
-            </Button>
+              <Button
+                onClick={this.toggleCard}
+                theme={{ button: styles.toggleButton }}
+              >
+                {
+                  icon &&
+                    (
+                      <Icon
+                        icon={icon}
+                        theme={{
+                          icon: isOpen ? styles.icon : styles.iconCollapse
+                        }}
+                      />
+                    )
+                }
+              </Button>
+            </div>
           </div>
           {children}
         </div>
@@ -62,19 +74,23 @@ AccordionCard.propTypes = {
   icon: PropTypes.shape({}),
   /** Text to be displayed as header */
   title: PropTypes.string.isRequired,
+  /** Counter of active elements */
+  counter: PropTypes.number,
   /** Any data structure to render */
   children: PropTypes.node,
   /** Theming checkbox with customized styles */
   theme: PropTypes.shape({
     cardContainer: PropTypes.string,
     headerContainer: PropTypes.string,
-    groupTitle: PropTypes.string
+    groupTitle: PropTypes.string,
+    groupCounter: PropTypes.string
   })
 };
 
 AccordionCard.defaultProps = {
   isOpen: false,
   icon: chevronIcon,
+  counter: null,
   theme: {},
   children: null
 };

--- a/src/components/dropdown/dropdown-styles.scss
+++ b/src/components/dropdown/dropdown-styles.scss
@@ -44,6 +44,7 @@
   border-bottom: 1px solid #1bcec7;
   list-style: none;
   margin: 0;
+  z-index: 1;
 
   &.closed {
     display: none;


### PR DESCRIPTION
Needed a counter of layers active in the accordion grid using a new props... it is not the best way but it is the quickest for now:

![image](https://user-images.githubusercontent.com/10500650/46025155-920be980-c0e8-11e8-8dbc-9477734317fa.png)

